### PR TITLE
Enable ORT SPM dependency to be added via version tag

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,11 +5,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 //
-// A user of the Swift Package Manager (SPM) package will consume this file directly from the ORT github repository.
+// A user of the Swift Package Manager (SPM) package will consume this file directly from the ORT SPM github repository.
 // For context, the end user's config will look something like:
 //
 //     dependencies: [
-//       .package(url: "https://github.com/microsoft/onnxruntime", from: "1.15.0"), 
+//       .package(url: "https://github.com/microsoft/onnxruntime-swift-package-manager", from: "1.15.0"), 
 //       ...
 //     ],
 //

--- a/Package.swift
+++ b/Package.swift
@@ -9,8 +9,7 @@
 // For context, the end user's config will look something like:
 //
 //     dependencies: [
-//        #TODO: update to use release 'version' and the new repo url here when available
-//       .package(url: "https://github.com/microsoft/onnxruntime", branch: "rel-1.15.0"), 
+//       .package(url: "https://github.com/microsoft/onnxruntime", from: "1.15.0"), 
 //       ...
 //     ],
 //


### PR DESCRIPTION
Context:
- Released a version tag 1.15.0 on this onnxruntime-swift-package-manager repo in sync with the ORT main objc/ & swift/ files:
    - https://github.com/microsoft/onnxruntime-swift-package-manager/releases
- Tested usage of adding SPM using version instead of branch in the test iOS swift app.

This pr's change:

- Updated comments in Package.swift about user's dependency config.