### PR TITLE
Remove unsafe flags in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -44,11 +44,6 @@ let package = Package(
                             "include/onnxruntime_training.h"],
                 cxxSettings: [
                     .define("SPM_BUILD"),
-                    .unsafeFlags(["-std=c++17",
-                                  "-fobjc-arc-exceptions"
-                                 ]),
-                ], linkerSettings: [
-                    .unsafeFlags(["-ObjC"]),
                 ]),
         .testTarget(name: "OnnxRuntimeBindingsTests",
                     dependencies: ["OnnxRuntimeBindings"],
@@ -61,11 +56,6 @@ let package = Package(
                 path: "extensions",
                 cxxSettings: [
                     .define("ORT_SWIFT_PACKAGE_MANAGER_BUILD"),
-                    .unsafeFlags(["-std=c++17",
-                                  "-fobjc-arc-exceptions"
-                                 ]),
-                ], linkerSettings: [
-                    .unsafeFlags(["-ObjC"]),
                 ]),
         .testTarget(name: "OnnxRuntimeExtensionsTests",
                     dependencies: ["OnnxRuntimeExtensions", "OnnxRuntimeBindings"],
@@ -73,7 +63,8 @@ let package = Package(
                     resources: [
                         .copy("Resources/decode_image.onnx")
                     ]),
-    ]
+    ],
+    cxxLanguageStandard: .cxx17
 )
 
 // Add the ORT iOS Pod archive as a binary target.


### PR DESCRIPTION
Remove unsafe flags in Package.swift due to a customer's issue.

unsafe flags not working when specifying spm via version: https://forums.swift.org/t/question-about-contains-unsafe-build-flags-in-spm/47677/4