### PR TITLE
Fix MinimumOSVersion for onnxruntime.xcframework

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -98,9 +98,9 @@ if let pod_archive_path = ProcessInfo.processInfo.environment["ORT_POD_LOCAL_PAT
     // ORT release
     package.targets.append(
        Target.binaryTarget(name: "onnxruntime",
-                           url: "https://download.onnxruntime.ai/pod-archive-onnxruntime-c-1.19.2.zip",
+                           url: "https://storage.googleapis.com/dev-nah-onnxruntime-swift-package-manager/pod-archive-onnxruntime-c-1.19.2.zip",
                            // SHA256 checksum
-                           checksum: "28787ee2f966a2c47eb293322c733c5dc4b5e3327cec321c1fe31a7c698edf68")
+                           checksum: "3fa6cc4f316928c9236aa68a607a37960d2398c4ae32fb327fe149ec2370c093")
     )
 }
 


### PR DESCRIPTION
Avoid the issue where onnxruntime.framework does not define a MinimumOSVersion, causing an error after deployment to App Store Connect.

![image](https://github.com/user-attachments/assets/f8651550-86e6-4e2f-9968-b55e9c587522)
